### PR TITLE
Add custom generative process docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,3 +77,7 @@ prefix = your_s3_prefix
 ```
 
 [AWS configuration and credential files](https://docs.aws.amazon.com/cli/v1/userguide/cli-configure-files.html) can be used for authentication and settings. Authentication credentials should be specified in `~/.aws/credentials`. Settings like `region`, `output`, `endpoint_url` should be specified in `~/.aws/config`. Multiple different profiles can be defined and the specific profile to use can be specified in the `aws` section of the `.ini` file.
+
+## Further Documentation
+
+Detailed guides for each module can be found in the [documentation](documentation) directory. Start with `documentation/index.md` for an overview of available resources.

--- a/documentation/architecture_overview.md
+++ b/documentation/architecture_overview.md
@@ -1,0 +1,49 @@
+# Architecture Overview
+
+Simplexity is organised into modular packages. Each package focuses on a particular aspect of sequence modelling and can be used independently. The following summary highlights the main responsibilities of each module so that both developers and automated agents know where to look for functionality.
+
+## `generative_processes`
+
+Defines probabilistic processes used to generate training and evaluation data. Key classes include:
+
+- **`GenerativeProcess`** – an abstract base class defining the common interface.
+- **`HiddenMarkovModel`** and **`GeneralizedHiddenMarkovModel`** – concrete implementations driven by transition matrices.
+- **`builder.py`** – factory helpers for constructing processes from predefined transition matrix functions in `transition_matrices.py`.
+
+## `predictive_models`
+
+Predictive models take sequences of observations and predict the next token. The provided implementation is:
+
+- **`GRURNN`** – a GRU based recurrent neural network defined in `gru_rnn.py`.
+
+The `predictive_model.py` module defines a lightweight `Protocol` specifying the call signature for models.
+
+## `training`
+
+Contains high level training loops built with [equinox](https://github.com/patrick-kidger/equinox) and [optax](https://github.com/deepmind/optax). Training is driven by Hydra configuration objects located in `simplexity/configs/training`. The `train_equinox_model.py` module exposes a `train()` function which performs batched data generation, loss computation and parameter updates.
+
+## `evaluation`
+
+Mirrors the training utilities but focuses on computing metrics such as accuracy and loss without updating model parameters. See `evaluate_equinox_model.py` for the main entry point.
+
+## `persistence`
+
+Facilities for saving and loading trained model weights. `LocalPersister` writes to the local file system while `S3Persister` can upload checkpoints to an S3 bucket. These are used inside the training loops.
+
+## `logging`
+
+A very small abstraction over experiment logging backends. Currently provided loggers include printing to stdout, writing to a file and logging to MLflow.
+
+## `data_structures`
+
+Simple PyTree aware data structures (`Stack`, `Queue`, `Heap`) implemented using Equinox modules. Useful when writing JAX code that manipulates collections inside `jit`ted functions.
+
+## Utilities
+
+The `utils` package contains helpers for JAX and Hydra integration.
+
+## Tests
+
+The `tests/` directory provides unit tests for most submodules. Running `pytest` is the easiest way to confirm that modifications have not broken existing functionality.
+
+Use this overview as a starting point when navigating the code base. For extension guidelines see [Extending Simplexity](./extending.md).

--- a/documentation/data_structures.md
+++ b/documentation/data_structures.md
@@ -1,0 +1,17 @@
+# Data Structures
+
+The library includes a few simple data structures implemented with Equinox to ensure compatibility with JAX transformations such as `jit` and `vmap`. These structures are helpful when writing algorithms that maintain state inside compiled functions.
+
+## Queue
+
+Implemented in `simplexity/data_structures/queue.py`. Supports `enqueue`, `dequeue`, `peek` and `clear` operations. Internally uses two `Stack` instances so that pushing and popping remain efficient under JAX.
+
+## Stack
+
+Located at `simplexity/data_structures/stack.py`. Provides `push`, `pop`, `peek` and `clear`. A `max_size` parameter limits the number of stored elements which makes it suitable for static allocation within JAX functions.
+
+## Heap
+
+Implemented in `simplexity/data_structures/heap.py`. Offers push and pop operations for maintaining a priority queue. Useful for beam search style algorithms.
+
+All structures store JAX arrays or PyTree elements and can therefore be used inside `eqx.filter_jit` or `jax.jit` compiled code.

--- a/documentation/extending.md
+++ b/documentation/extending.md
@@ -1,0 +1,57 @@
+# Extending Simplexity
+
+This page provides guidance for developers and automated agents who need to add new functionality to the library. Because the codebase relies heavily on JAX and Equinox, many objects are functional and immutable by design. Follow the patterns below to keep new features consistent with the existing style.
+
+## Adding a New Generative Process
+
+1. Create transition matrices in `simplexity/generative_processes/transition_matrices.py`. Follow the existing function style where each process returns a tensor of shape `(vocab_size, num_states, num_states)`.
+2. Register the function in either `HMM_MATRIX_FUNCTIONS` or `GHMM_MATRIX_FUNCTIONS` depending on whether your process is a standard HMM or a generalised HMM.
+3. Use the builders in `simplexity/generative_processes/builder.py` to construct the process. This ensures parameter validation and consistent initial state handling.
+4. Add unit tests under `tests/generative_processes` to validate probability distributions and state transitions.
+
+### Custom Processes
+
+The library does not restrict generative processes to HMM-style transition matrices. To implement a completely new process, create a class deriving from `GenerativeProcess` (see `generative_processes/generative_process.py`). Implement the required methods:
+
+```python
+class MyProcess(GenerativeProcess[MyState]):
+    @property
+    def vocab_size(self) -> int: ...
+
+    @property
+    def initial_state(self) -> MyState: ...
+
+    def emit_observation(self, state: MyState, key: chex.PRNGKey) -> chex.Array: ...
+
+    def transition_states(self, state: MyState, obs: chex.Array) -> MyState: ...
+
+    def observation_probability_distribution(self, state: MyState) -> jax.Array: ...
+
+    def log_observation_probability_distribution(self, log_state: MyState) -> jax.Array: ...
+
+    def probability(self, observations: jax.Array) -> jax.Array: ...
+
+    def log_probability(self, observations: jax.Array) -> jax.Array: ...
+```
+
+This approach allows arbitrary internal state and emission logic. You can still use the training and evaluation utilities as long as your class conforms to the interface.
+
+## Implementing a New Predictive Model
+
+1. Define your model in `simplexity/predictive_models/`. Models should implement the `PredictiveModel` protocol found in `predictive_model.py`.
+2. If the model has trainable parameters, make it an `equinox.Module` so that parameters can be updated functionally.
+3. Provide a factory function (e.g. `build_my_model`) that constructs the model given a vocabulary size and random seed.
+4. Add configuration options under `simplexity/configs/predictive_model` if the model requires specific hyperparameters.
+5. Write unit tests in `tests/predictive_models`.
+
+## Training Loops
+
+Training utilities live under `simplexity/training`. If you create a new loop, mirror the call signature of `train_equinox_model.train()` so that configuration files and loggers remain interchangeable.
+
+## Persistence and Logging
+
+If a new persister or logger is required, implement it alongside the existing modules in `simplexity/persistence` or `simplexity/logging`. Both systems use simple abstract base classes, so minimal boilerplate is needed.
+
+## Keeping Documentation in Sync
+
+Whenever you add a significant new module, update this documentation folder to describe its purpose and usage. Clear docs make it easier for automated agents to stay aligned with the code.

--- a/documentation/index.md
+++ b/documentation/index.md
@@ -1,0 +1,20 @@
+# Simplexity Documentation
+
+Welcome to the **Simplexity** documentation. This folder provides a detailed guide to the library's structure, components, and usage patterns.
+
+The goal is twofold:
+
+1. **Help new users** quickly understand how to install and use the library.
+2. **Assist automated agents** (such as LLM-based tools) in locating key functions and extending the codebase.
+
+The document set is intentionally verbose so that both humans and LLMs can easily search for relevant information. Below you will find high-level overviews as well as links to more detailed pages for each module.
+
+## Contents
+
+- [Project Overview](./project_overview.md)
+- [Using the Library](./using_library.md)
+- [Architecture Notes](./architecture_overview.md)
+- [Extending Simplexity](./extending.md)
+- [Data Structures](./data_structures.md)
+
+Each page is written in plain Markdown and is meant to be read directly or consumed programmatically by an LLM agent.

--- a/documentation/project_overview.md
+++ b/documentation/project_overview.md
@@ -1,0 +1,25 @@
+# Project Overview
+
+Simplexity is a Python library for exploring sequence prediction models from a Computational Mechanics perspective. It contains implementations of generative processes, predictive models and utilities for training, evaluating and persisting models. The code targets Python 3.12 and makes heavy use of `jax` and `equinox` for high performance computation.
+
+This document summarises the main areas of the project so that new users and automated agents can easily locate relevant modules.
+
+## Repository Layout
+
+```
+README.md          - Quick start instructions
+notebooks/         - Example Jupyter notebooks
+simplexity/        - Core library code
+  configs/         - Hydra configuration files
+  data_structures/ - Queue, Stack and related utilities
+  evaluation/      - Model evaluation helpers
+  generative_processes/ - Hidden Markov Models and related processes
+  logging/         - Simple logging interfaces
+  persistence/     - Save and load model weights
+  predictive_models/ - Example models such as GRU RNNs
+  training/        - Training loops
+  utils/           - Small helper functions
+tests/             - Unit tests
+```
+
+If you are completely new to the project, start with [Using the Library](./using_library.md) which explains how to install dependencies and run a simple training session.

--- a/documentation/using_library.md
+++ b/documentation/using_library.md
@@ -1,0 +1,55 @@
+# Using the Library
+
+This guide walks through a minimal workflow for training and evaluating a model using Simplexity.
+
+## Installation
+
+1. Install [UV](https://docs.astral.sh/uv/getting-started/installation/):
+
+   ```bash
+   curl -LsSf https://astral.sh/uv/install.sh | sh
+   ```
+
+2. Install Simplexity dependencies:
+
+   ```bash
+   uv sync
+   ```
+
+   For development and testing extras run:
+
+   ```bash
+   uv sync --extra dev
+   ```
+
+   Dependencies are installed into a `.venv` directory managed by `uv`.
+
+## Training a Model
+
+Training is configured via [Hydra](https://hydra.cc/). The default configuration is in `simplexity/configs/train_model.yaml` and references other configuration files under `simplexity/configs/`.
+
+Run a training session with:
+
+```bash
+uv run python simplexity/train_model.py
+```
+
+This will use a GRU based predictive model and the `mess3` generative process by default. Training logs and checkpoints are written according to the configuration. See the configuration files for adjustable parameters such as batch size, learning rate and number of steps.
+
+## Running an Experiment
+
+Experiments allow you to sweep over multiple parameter settings using [Optuna](https://optuna.org/). Invoke an experiment with:
+
+```bash
+uv run python simplexity/run_experiment.py --multirun
+```
+
+Hydra will spawn multiple runs according to `simplexity/configs/experiment.yaml`.
+
+## Evaluating a Model
+
+The `simplexity/evaluation` package contains utilities for computing loss and accuracy over a validation set. Evaluation is typically run during training but can also be invoked separately.
+
+## Jupyter Notebooks
+
+The `notebooks/` directory contains exploratory notebooks demonstrating how to generate data, visualise processes and inspect trained models. They are a good starting point for learning the API interactively.


### PR DESCRIPTION
## Summary
- document how to implement your own GenerativeProcess
- point to docs directory from README
- include instructions for LLM agents in documentation

## Testing
- `python -m pytest -q` *(fails: No module named pytest)*